### PR TITLE
Add optional OCRmyPDF integration for PDF text layers

### DIFF
--- a/apps/file-brain/README.md
+++ b/apps/file-brain/README.md
@@ -153,3 +153,32 @@ docker pull hamza5/typesense-gpu:29.0-cuda11.8.0-cudnn8-runtime-ubuntu22.04
 ```
 
 _Note: Once the images are pulled and the model files are in place, File Brain will handle starting the services automatically on the next run._
+
+## Optional: PDF OCR Text Layer
+
+File Brain can optionally add searchable text layers to scanned PDFs using [OCRmyPDF](https://ocrmypdf.readthedocs.io/). This makes your scanned PDFs searchable in other applications as well, not just within File Brain.
+
+### Installation
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install ocrmypdf tesseract-ocr tesseract-ocr-eng
+```
+
+**macOS:**
+```bash
+brew install ocrmypdf
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S ocrmypdf tesseract tesseract-data-eng
+```
+
+### Enabling OCR
+
+1. Open File Brain
+2. Click the settings icon to open **Index Management**
+3. Toggle **Enable OCR Processing** in the PDF OCR card
+
+When enabled, PDFs will be processed with OCRmyPDF after indexing, adding a searchable text layer. PDFs that already have text are automatically skipped.

--- a/apps/file-brain/file_brain/services/crawler/indexer.py
+++ b/apps/file-brain/file_brain/services/crawler/indexer.py
@@ -108,6 +108,18 @@ class FileIndexer:
                 metadata=document_content.metadata,
             )
 
+        # OCR PDF if enabled (adds searchable text layer to scanned PDFs)
+        if Path(file_path).suffix.lower() == ".pdf":
+            from file_brain.services.ocrmypdf_service import (
+                is_ocrmypdf_enabled,
+                process_pdf_with_ocr,
+            )
+
+            if is_ocrmypdf_enabled():
+                success, error = process_pdf_with_ocr(file_path)
+                if not success and error:
+                    logger.warning(f"OCR processing failed for {file_path}: {error}")
+
         return True
 
     def _handle_delete_operation(self, operation: CrawlOperation) -> bool:

--- a/apps/file-brain/file_brain/services/ocrmypdf_service.py
+++ b/apps/file-brain/file_brain/services/ocrmypdf_service.py
@@ -1,0 +1,129 @@
+"""
+OCRmyPDF Service for adding text layers to scanned PDFs.
+
+This service provides optional OCR functionality that can be enabled
+via settings to add searchable text layers to PDF files after indexing.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+from file_brain.core.logging import logger
+from file_brain.database.models import db_session
+from file_brain.database.repositories import SettingsRepository
+
+# Setting key for OCR enabled toggle
+OCRMYPDF_ENABLED_KEY = "ocrmypdf_enabled"
+
+
+def is_ocrmypdf_available() -> Tuple[bool, str]:
+    """
+    Check if ocrmypdf CLI is available on the system.
+
+    Returns:
+        Tuple of (available: bool, version_or_error: str)
+    """
+    try:
+        result = subprocess.run(
+            ["ocrmypdf", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            version = result.stdout.strip().split("\n")[0]
+            return True, version
+        return False, "ocrmypdf returned error"
+    except FileNotFoundError:
+        return False, "ocrmypdf not installed"
+    except subprocess.TimeoutExpired:
+        return False, "ocrmypdf version check timed out"
+    except Exception as e:
+        return False, str(e)
+
+
+def is_ocrmypdf_enabled() -> bool:
+    """
+    Check if OCRmyPDF processing is enabled in settings.
+
+    Returns:
+        True if OCR processing is enabled, False otherwise.
+    """
+    with db_session() as db:
+        repo = SettingsRepository(db)
+        return repo.get_bool(OCRMYPDF_ENABLED_KEY, default=False)
+
+
+def process_pdf_with_ocr(pdf_path: str) -> Tuple[bool, Optional[str]]:
+    """
+    Process a PDF with OCRmyPDF to add a searchable text layer.
+
+    Uses --skip-text to avoid re-processing PDFs that already have text.
+    Modifies the PDF in-place on success.
+
+    Args:
+        pdf_path: Path to the PDF file to process.
+
+    Returns:
+        Tuple of (success: bool, error_message: Optional[str])
+    """
+    path = Path(pdf_path)
+
+    if not path.exists():
+        return False, f"File not found: {pdf_path}"
+
+    if path.suffix.lower() != ".pdf":
+        return False, "Not a PDF file"
+
+    # Create temp file for output
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+
+        # Run ocrmypdf with common optimization flags
+        result = subprocess.run(
+            [
+                "ocrmypdf",
+                "--skip-text",  # Skip pages that already have text
+                "--rotate-pages",  # Auto-rotate pages based on detected orientation
+                "--deskew",  # Straighten pages
+                "--clean",  # Clean up images before OCR
+                "--quiet",  # Less verbose output
+                str(pdf_path),
+                tmp_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,  # 5 minute timeout per PDF
+        )
+
+        if result.returncode == 0:
+            # Replace original with OCR'd version
+            shutil.move(tmp_path, pdf_path)
+            logger.info(f"Successfully OCR'd PDF: {pdf_path}")
+            return True, None
+        elif result.returncode == 6:
+            # Exit code 6 = "Document already has text, skipping"
+            logger.debug(f"PDF already has text layer, skipping: {pdf_path}")
+            Path(tmp_path).unlink(missing_ok=True)
+            return True, None
+        else:
+            error = result.stderr or f"Exit code: {result.returncode}"
+            logger.warning(f"OCRmyPDF failed for {pdf_path}: {error}")
+            Path(tmp_path).unlink(missing_ok=True)
+            return False, error
+
+    except subprocess.TimeoutExpired:
+        logger.error(f"OCRmyPDF timed out for {pdf_path}")
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+        return False, "OCR processing timed out"
+    except Exception as e:
+        logger.error(f"OCRmyPDF error for {pdf_path}: {e}")
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+        return False, str(e)

--- a/apps/file-brain/frontend/src/api/client.ts
+++ b/apps/file-brain/frontend/src/api/client.ts
@@ -917,3 +917,26 @@ export interface IndexStorageResponse {
 export async function getIndexStorage(): Promise<IndexStorageResponse> {
   return requestJSON("/api/v1/stats/index-storage");
 }
+
+// OCRmyPDF Settings API
+export interface OcrStatus {
+  available: boolean;
+  version: string | null;
+  error: string | null;
+  enabled: boolean;
+  setting_key: string;
+}
+
+export async function getOcrStatus(): Promise<OcrStatus> {
+  return requestJSON("/api/v1/config/settings/ocrmypdf-status");
+}
+
+export async function updateSetting(
+  key: string,
+  value: string
+): Promise<{ key: string; value: string; description: string | null }> {
+  return requestJSON(
+    `/api/v1/config/settings/${encodeURIComponent(key)}?value=${encodeURIComponent(value)}`,
+    { method: "PUT" }
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds an optional feature to run OCRmyPDF on indexed PDFs, adding searchable text layers to scanned documents. This makes scanned PDFs searchable not just within File Brain, but also in other PDF applications.

### Changes

- **New service module** (`ocrmypdf_service.py`): Functions to check OCRmyPDF availability and process PDFs
- **Indexer integration**: OCR runs after successful indexing when enabled
- **New API endpoint** (`/ocrmypdf-status`): Returns installation status and settings
- **Frontend toggle**: Added to Index Management sidebar with availability status
- **Documentation**: Installation instructions for ocrmypdf on Linux/macOS

### Key Features

- **Disabled by default**: Users must explicitly enable OCR processing
- **Graceful degradation**: If ocrmypdf isn't installed, the toggle is disabled with a helpful message
- **Smart processing**: Uses `--skip-text` flag to skip PDFs that already have text layers
- **Non-blocking**: OCR failures don't prevent file indexing

### Screenshots

The new OCR toggle appears in the Index Management sidebar alongside existing options.

## Test Plan

- [ ] Verify toggle appears in Index Management sidebar
- [ ] Confirm toggle is disabled when ocrmypdf is not installed
- [ ] Enable OCR, index a scanned PDF, verify text layer is added
- [ ] Verify PDFs with existing text are skipped (not re-processed)
- [ ] Test with ocrmypdf installed/uninstalled