### PR TITLE
Fix website build missing GitHub star count

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Fetch GitHub stars
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node apps/website/scripts/fetch-github-stars.mjs
-        working-directory: .
+        run: node scripts/fetch-github-stars.mjs
+        working-directory: apps/website
 
       - name: Build website
         env:


### PR DESCRIPTION
The website build process was failing to include the correct number of GitHub stars because the `fetch-github-stars.mjs` script was writing `.env.production` to the repository root (its working directory) instead of `apps/website`.

This change modifies the GitHub Actions workflow to run the script with `working-directory: apps/website`, ensuring the environment variables are correctly placed for the Next.js application to use during build time.

---
*PR created automatically by Jules for task [8323781122843683164](https://jules.google.com/task/8323781122843683164) started by @Hamza5*